### PR TITLE
use min-height in app-main

### DIFF
--- a/src/layout/app-main/index.vue
+++ b/src/layout/app-main/index.vue
@@ -129,9 +129,10 @@ watch(
   position: relative;
   overflow: hidden;
   background-color: var(--app-main-background);
+  min-height: calc(100vh - #{var(--nav-bar-height)}) !important;
 }
 .show-tag-view {
-  height: calc(100vh - #{var(--nav-bar-height)} - #{var(--tag-view-height)}) !important;
+  min-height: calc(100vh - #{var(--nav-bar-height)} - #{var(--tag-view-height)}) !important;
 }
 .fixed-header + .app-main {
   padding-top: 50px;


### PR DESCRIPTION
Set min-height when show-tag-view is false to fix extra space in the bottom.
This will also fix scroll issue if show-tag-view is false.
But this will be in conflict with scroll-y, x, xy in /styles/index.scss. So new component files can just remove them if necessary.

